### PR TITLE
コードハイライトを正しく表示させる

### DIFF
--- a/_posts/2014-06-01-smallest-app.md
+++ b/_posts/2014-06-01-smallest-app.md
@@ -95,6 +95,7 @@ Running via Spring preloader in process 82284
 もしもrails g コマンドを打ち間違えて違うファイルを作ってしまった場合は、打ち間違えたコマンドの g の部分を d にして再実行すると、rails g コマンドで作成したファイルをまとめて削除してくれます。たとえば、``` rails g controller hell index``` とhelloをhellと打ち間違えた場合は、``` rails d controller hell index``` コマンドを実行することで間違えて作ったファイル群を削除することができます。（ターミナルでカーソルキーの↑キーを押すと、さきほど入力した内容が出てくるので、それを利用して g を d に直すと楽に実行できます。）
 
 再びrails server を起動させましょう。
+
 ```bash
 rails s
 ```


### PR DESCRIPTION
@igaiga コードハイライトさせるときにスペースがなかったために、表示が崩れていたのを修正しました。
修正前
![image](https://cloud.githubusercontent.com/assets/5152601/13076670/2a162e06-d4f7-11e5-92a4-8317e456a697.png)

修正後
![image](https://cloud.githubusercontent.com/assets/5152601/13076674/355602d2-d4f7-11e5-8116-47f005c52227.png)

今回はとりあえずPR出したのですが、こういった類の微妙なやつはわざわざPR出さないでGitHub上のコメントのほうがよかったりしますか...？