### PR TITLE
_form.html.erbのPath追加

### DIFF
--- a/_posts/2014-08-01-new-create.md
+++ b/_posts/2014-08-01-new-create.md
@@ -93,6 +93,7 @@ render メソッドは別のビューファイルを埋め込みます。埋め�
 また、`<%= render 'form', book: @book %>` の `book: @book` の部分は、 `@book` 変数を埋め込み先のパーシャル内では `book` 変数として使うように渡す指示です。
 
 埋め込まれるパーシャルビュー `_form.html.erb` は以下のようになっています。
+ファイルは`app/views/books/_form.html.erb`です。
 
 ```erb
 <%= form_for(book) do |f| %>


### PR DESCRIPTION
@igaiga 修正が1点、相談が1点あります。

まず修正についてですがパーシャルビュー`_form.html.erb`のコードを説明する際にファイルのPathが明記されていませんでした。後で出てくる画像による説明でPathは明記されていますが、他のファイル同様にコードが最初に出てきたときにPathも一緒にあったほうが親切かなぁと思いpathを追加修正しました。

次に相談したいことは`new.html.erb`の動作を説明している画像`assets/new-create/kn/new-flow-view.png`についてです。画像中ではrenderの部分を

```ruby
<%= render 'form' %>
```

としていますが、文章中では

```ruby
<%= render 'form', book: @book %>
```

として説明をしています。僕の環境(4.2系)では`<%= render 'form' %>`、上のパターンなのですが5系だと下のパターンなのでしょうか。もし画像を文章に合わせるのでしたら画像の修正が必要になると思いますがどうでしょうか？
![image](https://cloud.githubusercontent.com/assets/5152601/13080098/9402c35c-d50a-11e5-8adf-589b85db1a15.png)
