### PR TITLE
モデル生成時のtypoを修正

### DIFF
--- a/_posts/2014-09-01-model.md
+++ b/_posts/2014-09-01-model.md
@@ -326,12 +326,12 @@ $ rails db:migrate
 rails g コマンドにmodelを指定するとmodelとmigrationを生成できます。
 
 ```ruby
-rails g model books title:string memo:text
+rails g model book title:string memo:text
 ```
 
 ```console
 db/migrate/20160216060032_create_books.rb
-app/models/books.rb
+app/models/book.rb
 ```
 
 ## 応用編：rails g コマンドまとめ


### PR DESCRIPTION
@igaiga `rails g model モデル名(単数)`となるところが複数形になっていたので修正しました。