### PR TITLE
fix URL of "Learn to Program"

### DIFF
--- a/_posts/2016-02-17-postface.md
+++ b/_posts/2016-02-17-postface.md
@@ -57,7 +57,7 @@ Railsの基礎から応用まで網羅した書籍です。実際にRailsでプ�
 Rubyの教科書といえばこの本、という名著です。分かり易く、丁寧に、かつ網羅的にRubyの説明をしています。最新の第五版が2016年2月に発売されています。
 
 - プログラミング入門　- Rubyを使って -
-  - [`http://www.ie.u-ryukyu.ac.jp/~kono/software/s04/tutorial/Chapter=Contents.html`](http://www.ie.u-ryukyu.ac.jp/~kono/software/s04/tutorial/Chapter=Contents.html)
+  - [`http://www.ie.u-ryukyu.ac.jp/~kono/software/s04/tutorial/`](http://www.ie.u-ryukyu.ac.jp/~kono/software/s04/tutorial/)
 
 Chris Pineさんが書かれたRubyの入門文書の日本語訳です。やや古い文書なので、インストールに利用しているRubyのバージョンは古くなっていまが、本書で作った開発環境があればインストール作業不要で読み進めることができます。プログラミングとRubyの基礎を丁寧に説明している素晴らしい文書です。
 


### PR DESCRIPTION
『プログラミング入門　- Rubyを使って -』のURLが長くてページのおさまりが悪いなあ…と思っていたのですが、よく見るともっと短いURLが正しいもののようなので修正してみました。