### PR TITLE
説明文に記載されているカラム名のtypoを修正

### DIFF
--- a/_posts/2016-01-12-picture-upload.md
+++ b/_posts/2016-01-12-picture-upload.md
@@ -51,7 +51,7 @@ class AddPictureToBooks < ActiveRecord::Migration[6.0]
 end
 ```
 
-生成されたmigrationファイルには、booksテーブルへauthorカラムをstring型で追加する指示が書かれています。
+生成されたmigrationファイルには、booksテーブルへpictureカラムをstring型で追加する指示が書かれています。
 
 migrationファイルを作成したら、`rails db:migrate`コマンドでDBへ内容を反映します。
 


### PR DESCRIPTION
7章「画像アップロード機能の追加」に対する修正です。
migrationファイルの説明で、文章では「`booksテーブルへauthorカラムをstring型で追加する指示が書かれています。`」とありますが、実際に追加されたカラム名は`picture`となっていたので、文中のテキストを修正しました。