### PR TITLE
fix typo

### DIFF
--- a/_posts/2014-04-01-preface.md
+++ b/_posts/2014-04-01-preface.md
@@ -107,7 +107,7 @@ Webアプリのプログラムを書くための道具として、ターミナ�
 
 エディタはプログラムを入力する道具です。エディタは好みのものがあればそれを利用してください。特にない場合は [Visual Studio Code](https://code.visualstudio.com/) をお勧めします。Visual Studio Codeは無料で使うことができます。ライセンスはMITライセンスです。
 
-ブラウザはつくったWebアプリへアクセスするための道具としてつかいます。お好きなものをご利用いただけますが、文中で説明につかわれている [Chrome](https://www.google.co.jp/chrome/browser/) 使うと分かりやすいです。
+ブラウザはつくったWebアプリへアクセスするための道具としてつかいます。お好きなものをご利用いただけますが、文中で説明につかわれている [Chrome](https://www.google.co.jp/chrome/browser/) を使うと分かりやすいです。
 
 もしもここに書いている内容でうまくいかない場合は、 [RailsGirlsガイド インストール・レシピ](https://railsgirls.jp/install) のページが新しい情報で更新されているので、こちらも参考にしてみてください。
 


### PR DESCRIPTION
「開発環境」に脱字と思われる箇所があったので修正しました！
修正前:ブラウザはつくったWebアプリへアクセスするための道具としてつかいます。お好きなものをご利用いただけますが、文中で説明につかわれている [Chrome](https://www.google.co.jp/chrome/browser/) 使うと分かりやすいです。
修正後:ブラウザはつくったWebアプリへアクセスするための道具としてつかいます。お好きなものをご利用いただけますが、文中で説明につかわれている [Chrome](https://www.google.co.jp/chrome/browser/) `を`使うと分かりやすいです。